### PR TITLE
Fix notebook build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     hostname: dask-scheduler
     ports:
       - "8786:8786"
+      - "8787:8787"
+    command: ["dask-scheduler"]
 
   worker:
     build:
@@ -16,13 +18,15 @@ services:
       dockerfile: Dockerfile
     image: daskdev/dask
     hostname: dask-worker
-    command: ["bash", "-c", "/usr/bin/prepare.sh && exec dask-worker scheduler:8786"]
+    ports:
+      - "8789:8789"
+    command: ["dask-worker scheduler:8786"]
 
   notebook:
     build:
-      context: .
-      dockerfile: notebook/Dockerfile
-    image: daskdev/base-notebook
+      context: ./notebook
+      dockerfile: Dockerfile
+    image: daskdev/dask-notebook
     hostname: notebook
     ports:
       - "8888:8888"

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -7,7 +7,7 @@ RUN conda install --yes -c conda-forge \
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager
 
 USER root
-COPY ./base/prepare.sh /usr/bin/prepare.sh
+COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
 RUN mkdir /opt/app
 USER $NB_USER

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -4,19 +4,19 @@ set -x
 
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
-    /opt/conda/bin/conda env update -n dask -f /opt/app/environment.yml
+    /opt/conda/bin/conda env update -f /opt/app/environment.yml
 else
     echo "no environment.yml"
 fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install -n dask $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/conda install $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then
     echo "EXTRA_PIP_PACKAGES environment variable found.  Installing".
-    /opt/conda/envs/dask/bin/pip install $EXTRA_PIP_PACKAGES
+    /opt/conda/bin/pip install $EXTRA_PIP_PACKAGES
 fi
 
 # Run extra commands

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+
+if [ -e "/opt/app/environment.yml" ]; then
+    echo "environment.yml found. Installing packages"
+    /opt/conda/bin/conda env update -n dask -f /opt/app/environment.yml
+else
+    echo "no environment.yml"
+fi
+
+if [ "$EXTRA_CONDA_PACKAGES" ]; then
+    echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
+    /opt/conda/bin/conda install -n dask $EXTRA_CONDA_PACKAGES
+fi
+
+if [ "$EXTRA_PIP_PACKAGES" ]; then
+    echo "EXTRA_PIP_PACKAGES environment variable found.  Installing".
+    /opt/conda/envs/dask/bin/pip install $EXTRA_PIP_PACKAGES
+fi
+
+# Run extra commands
+$@


### PR DESCRIPTION
The docker-hub build of the notebook image was failing due to a missing prepare.sh file.  For the short-term I've just copied over the file from base/ to notebook/ .  If there are cleaner ways to accomplish this I'd be glad for someone to fix this.

I've also added the bokeh diagnostic page ports to the docker-compose file