### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       dockerfile: Dockerfile
     image: daskdev/dask
     hostname: dask-worker
-    ports:
-      - "8789:8789"
     command: ["dask-worker scheduler:8786"]
 
   notebook:


### PR DESCRIPTION
remote port for worker. Used to scale up easily without port conflict in single machine. And container startup should be in order. docker-compose scale scheduler=1 notebook=1 worker=10