### PR TITLE
Update images to dask 0.17.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,24 +4,26 @@ FROM continuumio/miniconda3:4.3.14
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
 RUN chmod +x /usr/local/bin/dumb-init
 
-RUN conda create -n dask --yes -c conda-forge \
-    blosc \
+RUN conda update conda && conda install "conda=4.4.7"
+RUN conda create -n dask --yes \
+    python-blosc \
     cytoolz \
-    dask \
-    distributed \
-    fastparquet \
+    dask==0.17.0  \
+    distributed==1.21.0 \
     nomkl \
-    numpy \
-    pandas \
-    zict \
+    numpy==1.14.0 \
+    pandas==0.22.0 \
     && conda clean -tipsy
+
+RUN pip install git+https://github.com/dask/distributed.git@bc436e242884a1d4cf3a85ce6d5d378b5663122d \
+                --no-cache-dir \
+                --no-dependencies
+
 ENV PATH=/opt/conda/envs/dask/bin:$PATH
 
 COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
 
 RUN mkdir /opt/app
-
-RUN apt-get install git
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/bin/prepare.sh"]

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,26 +1,36 @@
 FROM jupyter/base-notebook
 
-RUN conda install --yes -c conda-forge \
-    dask \
-    distributed \
-    numpy \
-    pandas \
-    numba \
-    nomkl \
-    fastparquet \
-    zict \
-    blosc \
+USER root
+RUN apt-get update \
+  && apt-get install -yq --no-install-recommends graphviz git \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+USER $NB_USER
+
+RUN conda update conda && conda install "conda=4.4.7"
+RUN conda install --yes \
+    python-blosc \
     cytoolz \
+    dask==0.17.0  \
+    distributed==1.21.0 \
+    nomkl \
+    numpy==1.14.0 \
+    pandas==0.22.0 \
     ipywidgets \
-    git \
     jupyterlab \
     && conda clean -tipsy
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager
+RUN pip install graphviz \
+                git+https://github.com/dask/distributed.git@bc436e242884a1d4cf3a85ce6d5d378b5663122d \
+                --no-cache-dir \
+                --no-dependencies
 
 USER root
 COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
 RUN mkdir /opt/app
+COPY examples/ /home/$NB_USER/examples
+RUN chown -R $NB_USER /home/$NB_USER/examples
 USER $NB_USER
 
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -2,7 +2,7 @@ FROM jupyter/base-notebook
 
 USER root
 RUN apt-get update \
-  && apt-get install -yq --no-install-recommends graphviz git \
+  && apt-get install -yq --no-install-recommends graphviz git vim \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 USER $NB_USER


### PR DESCRIPTION
This also does the following:

1.  Removes fastparquet and numba
2.  Adds python-blosc, not just blosc
3.  Adds graphviz
4.  Adds example notebooks