### PR TITLE
Bump versions to distributed 1.21.4

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,7 +11,7 @@ RUN conda create -n dask --yes \
     dask==0.17.2  \
     distributed==1.21.4 \
     nomkl \
-    numpy==1.14.1 \
+    numpy==1.14.2 \
     pandas==0.22.0 \
     && conda clean -tipsy
 

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -11,10 +11,10 @@ RUN conda update conda && conda install "conda=4.4.7"
 RUN conda install --yes \
     python-blosc \
     cytoolz \
-    dask==0.17.1  \
-    distributed==1.21.1 \
+    dask==0.17.2  \
+    distributed==1.21.4 \
     nomkl \
-    numpy==1.14.1 \
+    numpy==1.14.2 \
     pandas==0.22.0 \
     ipywidgets \
     jupyterlab \


### PR DESCRIPTION
The two Dockerfiles of this repo where not updated in sync.

BTW, how are the docker images pushed to dockerhub and how is the tag of the image selected? Manually?