### PR TITLE
Use root environment in base docker image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,7 +5,7 @@ RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/
 RUN chmod +x /usr/local/bin/dumb-init
 
 RUN conda update conda && conda install "conda=4.4.7"
-RUN conda create -n dask --yes \
+RUN conda install --yes \
     python-blosc \
     cytoolz \
     dask==0.17.2  \
@@ -14,8 +14,6 @@ RUN conda create -n dask --yes \
     numpy==1.14.1 \
     pandas==0.22.0 \
     && conda clean -tipsy
-
-ENV PATH=/opt/conda/envs/dask/bin:$PATH
 
 COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh

--- a/base/prepare.sh
+++ b/base/prepare.sh
@@ -10,19 +10,19 @@ fi
 
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
-    /opt/conda/bin/conda env update -n dask -f /opt/app/environment.yml
+    /opt/conda/bin/conda env update -f /opt/app/environment.yml
 else
     echo "no environment.yml"
 fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install -n dask $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/conda install $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then
     echo "EXTRA_PIP_PACKAGES environment variable found.  Installing".
-    /opt/conda/envs/dask/bin/pip install $EXTRA_PIP_PACKAGES
+    /opt/conda/bin/pip install $EXTRA_PIP_PACKAGES
 fi
 
 # Run extra commands


### PR DESCRIPTION
The use of a virtual environment here might not be necessary (we don't expect users to make many conda environments within a docker container) and it can be confusing.  See https://gitter.im/dask/dev?at=5ac66b7d1130fe3d36a6dcdb

cc @yuvipanda

I haven't tested this yet.