### PR TITLE
fixed prepare.sh to avoid certain bugs

### DIFF
--- a/base/prepare.sh
+++ b/base/prepare.sh
@@ -26,4 +26,4 @@ if [ "$EXTRA_PIP_PACKAGES" ]; then
 fi
 
 # Run extra commands
-$@
+"$@"


### PR DESCRIPTION
For most users this won't make a difference, but users that use bash -c "<multiple commands>" at docker run there are important differences, namely it doesn't work without the quotes.

example of the difference:

test.sh:
>echo $@
>$@
>echo "$@"
>"$@"

$ bash test.sh bash -c "echo hello world; echo `pwd`"
>bash -c echo hello world; echo /home/joran
>
>bash -c echo hello world; echo /home/joran
>hello world
>/home/joran