### PR TITLE
update example03 to account for pandas.rolling() difference in v0.23.x

### DIFF
--- a/notebook/examples/03-dataframes-timeseries.ipynb
+++ b/notebook/examples/03-dataframes-timeseries.ipynb
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_small.rolling(100).mean().visualize(rankdir='LR')"
+    "df_small.value.rolling(100).mean().visualize(rankdir='LR')"
    ]
   }
  ],


### PR DESCRIPTION
Fixes #40 

Re-built container with `docker-compose up --build` after making the change to the notebook, and tested by running through the notebook again.