### PR TITLE
Added token='anon' and {'token': 'anon'} to gcsfs calls to public buckets

### DIFF
--- a/notebook/examples/05-nyc-taxi.ipynb
+++ b/notebook/examples/05-nyc-taxi.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "from gcsfs import GCSFileSystem\n",
-    "gcs = GCSFileSystem()\n",
+    "gcs = GCSFileSystem(token='anon')\n",
     "\n",
     "gcs.ls('anaconda-public-data/nyc-taxi/csv/2015/')"
    ]
@@ -89,7 +89,8 @@
    "source": [
     "import dask.dataframe as dd\n",
     "\n",
-    "df = dd.read_csv('gcs://anaconda-public-data/nyc-taxi/csv/2015/yellow_*.csv', \n",
+    "df = dd.read_csv('gcs://anaconda-public-data/nyc-taxi/csv/2015/yellow_*.csv',\n",
+    "                 storage_options={'token': 'anon'}, \n",
     "                 parse_dates=['tpep_pickup_datetime', 'tpep_dropoff_datetime'])"
    ]
   },

--- a/notebook/examples/06-nyc-parquet.ipynb
+++ b/notebook/examples/06-nyc-parquet.ipynb
@@ -44,7 +44,7 @@
     "import gcsfs\n",
     "import dask.dataframe as dd\n",
     "\n",
-    "df = dd.read_parquet('gcs://anaconda-public-data/nyc-taxi/nyc.parquet')\n",
+    "df = dd.read_parquet('gcs://anaconda-public-data/nyc-taxi/nyc.parquet', storage_options={'token': 'anon'})\n",
     "df = df.persist()\n",
     "progress(df)"
    ]


### PR DESCRIPTION
This gets-around issue where the default behaviour includes looking for GCE credential, which
fails when nor running on GCE.

See also https://github.com/dask/gcsfs/pull/144 which would remove the 'cloud' credentials search, making this change purely defensive.

This did not solve all Dask processing problems for me when running these examples in Docker containers.  You also need to run a script to install `gcsfs` on all worker nodes and notebook, and then there are some scale issues.  But it does allow the remote data to be read anonymously.