### PR TITLE
added '-y' flag to  command

### DIFF
--- a/base/prepare.sh
+++ b/base/prepare.sh
@@ -18,7 +18,7 @@ fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/conda install -y $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -17,7 +17,7 @@ fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/conda install -y $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then


### PR DESCRIPTION
Container launch was hanging on a "y/N" prompt from `conda`, so I added the '-y' flag to `conda install` command in both `prepare.sh` scripts.
