### PR TITLE
Add CI/CD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,5 @@ language: generic
 services:
   - docker
 
-env:
-  - DOCKER_COMPOSE_VERSION=1.24.1
-
-before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
 script:
   - docker-compose build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+services:
+  - docker
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.24.1
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+script:
+  - docker-compose build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,15 @@ services:
 
 script:
   - docker-compose build
+
+deploy:
+  - provider: script
+    script: bash ci/deploy.sh
+    on:
+      branch: master
+
+  - provider: script
+    skip_cleanup: true
+    script: bash ci/deploy.sh
+    on:
+      tags: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dask docker images
 
+[![Build Status](https://travis-ci.com/dask/dask-docker.svg?branch=master)](https://travis-ci.com/dask/dask-docker)
+
 Docker images for dask-distributed.
 
 1. Base image to use for dask scheduler and workers

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# Login to docker hub
+echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+
+# Iterate through built images and tag and push appropriately
+for IMAGE in $(cat docker-compose.yml | grep image: | awk '{ print $2 }'); do
+
+    # If this is not a tagged commit push to the dev label
+    if [ "$TRAVIS_TAG" = "" ]; then
+        DEV_IMAGE="$IMAGE:${TRAVIS_COMMIT:0:8}"
+        echo "Pushing $DEV_IMAGE"
+        docker tag $IMAGE $DEV_IMAGE
+        docker push $DEV_IMAGE
+
+    # If this is a tagged commit push to a new tag label and 'latest'
+    else
+        TAG_IMAGE="$IMAGE:$TRAVIS_TAG"
+        echo "Pushing $TAG_IMAGE"
+        docker tag $IMAGE $TAG_IMAGE
+        docker push $TAG_IMAGE
+
+        LATEST_IMAGE="$IMAGE:latest"
+        echo "Pushing $LATEST_IMAGE"
+        docker tag $IMAGE $LATEST_IMAGE
+        docker push $LATEST_IMAGE
+    fi
+
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: "3.1"
 
 services:
   scheduler:


### PR DESCRIPTION
Add Travis builds for docker images.

CI jobs will run `docker-compose build` to test that the images build successfully.

When pushed to master built images will be pushed to `daskdev/<image>:dev`. On tags the image will also be pushed to `daskdev/<image>:<tag>` and `daskdev/<image>:latest`.

Docker Hub credentials have been stored in Travis as environment variables which are only exposed on the master branch builds.