### PR TITLE
Add `jupyter-server-proxy`

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,6 +5,7 @@ RUN conda install --yes --freeze-installed \
     python-blosc \
     cytoolz \
     dask==2.3.0 \
+    jupyter-server-proxy \
     nomkl \
     numpy==1.16.2 \
     pandas==0.24.2 \


### PR DESCRIPTION
Added `jupyter-server-proxy` to enable being able to view the worker dashboards by default.