### PR TITLE
Use .gitattributes to configure line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare files that will always have CRLF line endings on checkout.
+*.sh text eol=lf


### PR DESCRIPTION
Possible fix for #38 

Issue
-----
Cloning a repository with git for windows will checkout files with CRLF line endings instead of LF. This behavior breaks running the container normally.

Error Message
----------------
```
[FATAL tini (7)] exec /usr/bin/prepare.sh failed: No such file or directory
```

Reproduce
------------

1. Clone the dask-docker repo on windows.
```
git --version
git version 2.16.0.windows.2
```

2. Build.
```
cd dask-docker
docker build --tag dask base/.
```

3. Run with `docker run dask dask-scheduler`

Fix
---
Use a .gitattributes to force the right line endings for certain files. In this case, we just need bash files to  use 'LF' line endings. [See more documentation here.](https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings)