### PR TITLE
DOC: Point to dask Helm Chart instead of dask-distributed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker images for dask-distributed.
 1. Base image to use for dask scheduler and workers
 2. Jupyter Notebook image to use as helper entrypoint
 
-This images are built primarily for the [dask Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/dask)
+This images are built primarily for the [Dask Helm Chart](https://github.com/dask/helm-chart)
 but they should work for more use cases.
 
 ## How to use / test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker images for dask-distributed.
 1. Base image to use for dask scheduler and workers
 2. Jupyter Notebook image to use as helper entrypoint
 
-This images are built primarily for the [dask-distributed Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/dask-distributed)
+This images are built primarily for the [dask Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/dask)
 but they should work for more use cases.
 
 ## How to use / test


### PR DESCRIPTION
I followed original link and saw that https://github.com/helm/charts/tree/master/stable/dask-distributed is Deprecated.