### PR TITLE
Fix joblib import error

### DIFF
--- a/notebook/examples/ml/sklearn-joblib.ipynb
+++ b/notebook/examples/ml/sklearn-joblib.ipynb
@@ -119,8 +119,7 @@
    "source": [
     "%%time\n",
     "\n",
-    "import dask_ml.joblib\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "\n",
     "with joblib.parallel_backend('dask', scatter=[X, y]):\n",
     "    grid_search.fit(X, y)"
@@ -185,7 +184,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`dask_ml.joblib `has been removed. This will use `joblib.parallel_backend` now.