### PR TITLE
Update Action version

### DIFF
--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Get latest Dask version
       id: latest_version
-      uses: jacobtomlinson/gha-anaconda-package-version@0.1.0
+      uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
       with:
         org: 'conda-forge'
         package: 'dask'


### PR DESCRIPTION
Update the GitHub Action for getting the latest anaconda package version. This now sorts semver package tags correctly.