### PR TITLE
Only deploy daskdev images

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -6,7 +6,7 @@ set -e
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
 
 # Iterate through built images and tag and push appropriately
-for IMAGE in $(cat docker-compose.yml | grep image: | awk '{ print $2 }'); do
+for IMAGE in $(cat docker-compose.yml | grep 'image: daskdev' | awk '{ print $2 }'); do
 
     # If this is not a tagged commit push to the dev label
     if [ "$TRAVIS_TAG" = "" ]; then


### PR DESCRIPTION
In https://github.com/dask/dask-docker/pull/89 we added a `jupyter/base-notebook:lab` image to `docker-compose.yml`. This leads to failures when we run our current deploy script (xref https://travis-ci.com/github/dask/dask-docker/builds/167524093#L2450-L2451). 

This PR changes our deploy script to only tag and push images in the `daskdev` organization. 

cc @jacobtomlinson 