### PR TITLE
EXTRA_APT_PACKAGES permission errors in notebook image

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -48,6 +48,3 @@ COPY --chown=1000:100 examples/ /home/$NB_USER/examples
 COPY prepare.sh /usr/bin/prepare.sh
 
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]
-
-USER $NB_USER
-CMD ["start.sh", "jupyter", "lab"]

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir /opt/app \
 COPY --chown=1000:100 examples/ /home/$NB_USER/examples
 COPY prepare.sh /usr/bin/prepare.sh
 
-USER $NB_USER
-
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]
+
+USER $NB_USER
 CMD ["start.sh", "jupyter", "lab"]

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -26,5 +26,8 @@ if [ "$EXTRA_PIP_PACKAGES" ]; then
     /opt/conda/bin/pip install $EXTRA_PIP_PACKAGES
 fi
 
+# Start jupyter here instead of Dockerfile so that ^^^ is executed as root
+su - $NB_USER && start.sh jupyter lab
+
 # Run extra commands
 exec "$@"

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -9,6 +9,9 @@ if [ "$EXTRA_APT_PACKAGES" ]; then
     apt install -y $EXTRA_APT_PACKAGES
 fi
 
+# Switch user so only ^^^ is executed as root
+su - $NB_USER
+
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
     /opt/conda/bin/conda env update -f /opt/app/environment.yml
@@ -26,8 +29,7 @@ if [ "$EXTRA_PIP_PACKAGES" ]; then
     /opt/conda/bin/pip install $EXTRA_PIP_PACKAGES
 fi
 
-# Start jupyter here instead of Dockerfile so that ^^^ is executed as root
-su - $NB_USER && start.sh jupyter lab
+start.sh jupyter lab
 
 # Run extra commands
 exec "$@"


### PR DESCRIPTION
This attempts to resolve #59 

I realized that changing the order of statements at the end of the Dockerfile wasn't going to solve the problem. However, moving the command that launches the Jupyter server from the container image itself into the prepare script called by the entry point seems to fix this in my local testing. I do now run into [other issues](https://github.com/sudo-project/sudo/issues/42) but they are minor and apparently unrelated.

Following the [testing guidelines](https://github.com/dask/dask-docker#how-to-use--test) I see a version mismatch warning between scheduler and workers, but that was there before my change and the rest of the output seems as expected:
```python
/opt/conda/lib/python3.8/site-packages/distributed/client.py:1136: VersionMismatchWarning: Mismatched versions found
+---------+---------------+---------------+---------------+
| Package | client        | scheduler     | workers       |
+---------+---------------+---------------+---------------+
| python  | 3.8.4.final.0 | 3.8.0.final.0 | 3.8.0.final.0 |
+---------+---------------+---------------+---------------+
  warnings.warn(version_module.VersionMismatchWarning(msg[0]["warning"]))
{'tcp://172.18.0.3:33481': 2}
```
