### PR TITLE
Add kubectl

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -3,12 +3,15 @@ FROM jupyter/base-notebook:lab
 USER root
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends graphviz git \
+    && apt-get install -yq --no-install-recommends curl graphviz git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -O /usr/local/bin/kubectl && \
-    chmod +x /usr/local/bin/kubectl
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    mkdir -p /usr/local/bin && \
+    mv ./kubectl /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    kubectl version --client
 
 USER $NB_USER
 

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -7,6 +7,9 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
 USER $NB_USER
 
 RUN conda install --yes \


### PR DESCRIPTION
Add the Kubectl binary to the Dask Jupyter image.

Useful for scaling workers up and down in the Dask Helm Chart.