### PR TITLE
Update JupyterLab tag

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:lab
+FROM jupyter/base-notebook:lab-2.2.5
 
 USER root
 


### PR DESCRIPTION
The previous generic tag "lab" no longer exists.
Now we use "lab-2.2.5"