### PR TITLE
Update auto PR action

### DIFF
--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -30,12 +30,13 @@ jobs:
           find: "dask==.* "
           replace: "dask==${{ steps.latest_version.outputs.version }} "
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update Dask version to ${{ steps.latest_version.outputs.version }}"
           title: "Update Dask version to ${{ steps.latest_version.outputs.version }}"
           reviewers: "jacobtomlinson"
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: "upgrade-dask-version"
           body: |
             A new Dask version has been detected.


### PR DESCRIPTION
GitHub Actions made some breaking changes so bumping the `peter-evans/create-pull-request` action to fix. 

Added the extra `author` option as per the [upgrading docs](https://github.com/peter-evans/create-pull-request/blob/master/docs/updating.md#updating-from-v2-to-v3).