### PR TITLE
Remove iid parameter in GridSearchCV

### DIFF
--- a/notebook/examples/ml/sklearn-joblib.ipynb
+++ b/notebook/examples/ml/sklearn-joblib.ipynb
@@ -85,7 +85,6 @@
     "grid_search = GridSearchCV(SVC(gamma='auto', random_state=0, probability=True),\n",
     "                           param_grid=param_grid,\n",
     "                           return_train_score=False,\n",
-    "                           iid=True,\n",
     "                           cv=3,\n",
     "                           n_jobs=-1)"
    ]


### PR DESCRIPTION
`iid` parameter was removed from `GridSearchCV` in Scikit-learn 0.24