### PR TITLE
Use `main` branch from scikit-learn

### DIFF
--- a/notebook/examples/ml/sklearn-joblib.ipynb
+++ b/notebook/examples/ml/sklearn-joblib.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Scale Scikit-Learn with Dask and Joblib\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/scikit-learn/scikit-learn/master/doc/logos/scikit-learn-logo-notext.png\"/> <img src=\"http://joblib.readthedocs.io/en/latest/_static/joblib_logo.svg\" width=\"20%\"/> \n",
+    "<img src=\"https://raw.githubusercontent.com/scikit-learn/scikit-learn/main/doc/logos/scikit-learn-logo-notext.png\"/> <img src=\"http://joblib.readthedocs.io/en/latest/_static/joblib_logo.svg\" width=\"20%\"/> \n",
     "\n",
     "Many Scikit-Learn operations already support parallelism with [joblib](http://joblib.readthedocs.io/) for single-machine parallelism. This lets you train most estimators (anything that accepts an `n_jobs` parameter) using all the cores of your laptop or workstation.\n",
     "\n",


### PR DESCRIPTION
Since it sounds like scikit-learn has already made this change ( https://github.com/dask/community/issues/68#issuecomment-767084497 ) and the URL seems to work fine

cc @jrbourbeau