### PR TITLE
Remove EXTRA_PIP_PACKAGES pointing to dev dask

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ should be pushed. Travis will then build the images and push them with version t
 `latest` too.
 
 ```console
-$ git commit --allow-empty -a -m "bump version to x.x.x"
+$ git commit --allow-empty -m "bump version to x.x.x"
 $ git tag -a x.x.x -m 'Version x.x.x'
 $ git push upstream main --tags
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       context: ./base
       dockerfile: Dockerfile
     image: daskdev/dask
-    environment:
-      - EXTRA_PIP_PACKAGES=git+https://github.com/dask/dask.git
     hostname: dask-scheduler
     ports:
       - "8786:8786"
@@ -19,8 +17,6 @@ services:
       context: ./base
       dockerfile: Dockerfile
     image: daskdev/dask
-    environment:
-      - EXTRA_PIP_PACKAGES=git+https://github.com/dask/dask.git
     hostname: dask-worker
     command: ["dask-worker", "tcp://scheduler:8786"]
 
@@ -31,8 +27,6 @@ services:
       args:
         PYTHON_VERSION: "3.8"
     image: jupyter/base-notebook:lab
-    environment:
-      - EXTRA_PIP_PACKAGES=git+https://github.com/dask/dask.git
 
   notebook:
     build:
@@ -46,4 +40,3 @@ services:
       - "8888:8888"
     environment:
       - DASK_SCHEDULER_ADDRESS="tcp://scheduler:8786"
-      - EXTRA_PIP_PACKAGES=git+https://github.com/dask/dask.git


### PR DESCRIPTION
This was erroneously added in https://github.com/dask/dask-docker/commit/2f4b7bf37707a094388e7a80103b2106ff37cdf1. I suspect I was messing around locally and accidentally committed these changes. This PR removes `EXTRA_PIP_PACKAGES` pointing to dev dask and also removes the `-a` option from `git commit` in our release instructions to help prevent this type of thing from happening in the future. 

cc @jacobtomlinson 

Closes https://github.com/dask/dask-docker/issues/146