### PR TITLE
Bumpy numpy==1.21.1 pandas==1.3.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,8 +8,8 @@ RUN conda install --yes \
     dask==2021.7.0 \
     lz4 \
     nomkl \
-    numpy==1.18.1 \
-    pandas==1.0.1 \
+    numpy==1.21.1 \
+    pandas==1.3.0 \
     tini==0.18.0 \
     && conda clean -tipsy \
     && find /opt/conda/ -type f,l -name '*.a' -delete \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -22,8 +22,8 @@ RUN conda install --yes \
     dask==2021.7.0 \
     lz4 \
     nomkl \
-    numpy==1.18.1 \
-    pandas==1.0.1 \
+    numpy==1.21.1 \
+    pandas==1.3.0 \
     ipywidgets \
     dask-labextension>=5 \
     python-graphviz \


### PR DESCRIPTION
Closes #164 

Looks like `dask-examples` CI is failing on `main` anyway so let's bump here and then try to fix CI over there after.

