### PR TITLE
Refactor README and make example cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Dask docker images
-
-[![Docker build](https://github.com/dask/dask-docker/actions/workflows/build.yml/badge.svg)](https://github.com/dask/dask-docker/actions/workflows/build.yml)
+# Dask docker images [![Docker build](https://github.com/dask/dask-docker/actions/workflows/build.yml/badge.svg)](https://github.com/dask/dask-docker/actions/workflows/build.yml)
 
 | Image  | Description | Versions |
 | ------------- | ------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 # Dask docker images
 
-[![Build Status](https://travis-ci.com/dask/dask-docker.svg?branch=main)](https://travis-ci.com/dask/dask-docker)
+[![Docker build](https://github.com/dask/dask-docker/actions/workflows/build.yml/badge.svg)](https://github.com/dask/dask-docker/actions/workflows/build.yml)
 
-Docker images for dask-distributed.
+| Image  | Description | Versions |
+| ------------- | ------------- | ------------- |
+| `daskdev/dask`  | Base image to use for Dask scheduler and workers  |   [![](https://img.shields.io/badge/daskdev%2Fdask-2021.8.0--py3.8-blue) ![](https://img.shields.io/badge/daskdev%2Fdask-2021.8.0-blue) ![](https://img.shields.io/badge/daskdev%2Fdask-latest-blue) <br /> ![](https://img.shields.io/badge/daskdev%2Fdask-2021.8.0--py3.9-blue)](https://hub.docker.com/r/daskdev/dask/tags)  |
+| `daskdev/notebook`  | Jupyter Notebook image to use as helper entrypoint  | [![](https://img.shields.io/badge/daskdev%2Fnotebook-2021.8.0--py3.8-blue) ![](https://img.shields.io/badge/daskdev%2Fnotebook-2021.8.0-blue) ![](https://img.shields.io/badge/daskdev%2Fnotebook-latest-blue) <br /> ![](https://img.shields.io/badge/daskdev%2Fnotebook-2021.8.0--py3.9-blue)](https://hub.docker.com/r/daskdev/notebook/tags) |
 
-1. Base image to use for dask scheduler and workers
-2. Jupyter Notebook image to use as helper entrypoint
 
-This images are built primarily for the [Dask Helm Chart](https://github.com/dask/helm-chart)
-but they should work for more use cases.
+## Example
 
-## How to use / test
+An example `docker-compose.yml` file is included for starting a small cluster.
 
-A helper docker-compose file is provided to test functionality.
-
-```
+```bash
 docker-compose up
 ```
 
@@ -24,28 +22,14 @@ On a new notebook run:
 
 ```python
 from dask.distributed import Client
-client = Client('scheduler:8786')
+client = Client()  # The address is automatically set by the DASK_SCHEDULER_ADDRESS environment variable
 client.ncores()
 ```
 
 It should output something like this:
 
-```
+```python
 {'tcp://172.23.0.4:41269': 4}
-```
-
-### Cross building
-
-The images can be cross-built using docker buildx bake. However buildx bake does not listen to `depends_on` (since in theory that is only a runtime not a build time constraint https://github.com/docker/buildx/issues/447). To work around this we first need to build the "base-notebook" image.
-
-```
-# If you have permission to push to daskdev/
-docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --push base-notebook
-docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --push
-# If you don'tset DOCKERUSER to your dockerhub username.
-export DOCKERUSER=holdenk
-docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --set base-notebook.tags.image=${DOCKERUSER}/base-notebook:lab-py38 --push base-notebook
-docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --set scheduler.tags=${DOCKERUSER}/dask --set worker.tags=${DOCKERUSER}/dask --set notebook.tags=${DOCKERUSER}/dask-notebook --set base-notebook.tags=${DOCKERUSER}/base-notebook:lab-py38 --set notebook.args.base=${DOCKERUSER} --push
 ```
 
 ## Environment Variables
@@ -65,11 +49,30 @@ The notebook image supports the following additional environment variables:
 
 Docker compose provides an easy way to building all the images with the right context
 
-```
+```bash
+cd build
+
 docker-compose build
 
 # Just build one image e.g. notebook
 docker-compose build notebook
+```
+
+### Cross building
+
+The images can be cross-built using `docker buildx bake`. However buildx bake does not listen to `depends_on` (since in theory that is only a runtime not a build time constraint https://github.com/docker/buildx/issues/447). To work around this we first need to build the "base-notebook" image.
+
+```bash
+cd build
+
+# If you have permission to push to daskdev/
+docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --push base-notebook
+docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --push
+
+# If you don'tset DOCKERUSER to your dockerhub username.
+export DOCKERUSER=holdenk
+docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --set base-notebook.tags.image=${DOCKERUSER}/base-notebook:lab-py38 --push base-notebook
+docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --set scheduler.tags=${DOCKERUSER}/dask --set worker.tags=${DOCKERUSER}/dask --set notebook.tags=${DOCKERUSER}/dask-notebook --set base-notebook.tags=${DOCKERUSER}/base-notebook:lab-py38 --set notebook.args.base=${DOCKERUSER} --push
 ```
 
 ## Releasing

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3.1"
+
+services:
+  scheduler:
+    build:
+      context: ../base
+      dockerfile: Dockerfile
+      args:
+        release: "2021.8.0"
+    image: daskdev/dask
+    hostname: dask-scheduler
+    ports:
+      - "8786:8786"
+      - "8787:8787"
+    command: ["dask-scheduler"]
+
+  base-notebook:
+    build:
+      context: github.com/jupyter/docker-stacks.git#master:base-notebook
+      dockerfile: Dockerfile
+      args:
+        python: "3.8"
+    image: daskdev/base-notebook:lab
+
+  worker:
+    build:
+      context: ../base
+      dockerfile: Dockerfile
+    image: daskdev/dask
+    hostname: dask-worker
+    command: ["dask-worker", "tcp://scheduler:8786"]
+
+  notebook:
+    build:
+      context: ../notebook
+      dockerfile: Dockerfile
+      args:
+        base: daskdev
+        python: "3.8"
+    depends_on:
+      - base-notebook
+    image: daskdev/dask-notebook
+    hostname: notebook
+    ports:
+      - "8888:8888"
+    environment:
+      - DASK_SCHEDULER_ADDRESS="tcp://scheduler:8786"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,45 +2,22 @@ version: "3.1"
 
 services:
   scheduler:
-    build:
-      context: ./base
-      dockerfile: Dockerfile
-      args:
-        release: "2021.8.0"
-    image: daskdev/dask
-    hostname: dask-scheduler
+    image: daskdev/dask:latest
+    hostname: scheduler
     ports:
       - "8786:8786"
       - "8787:8787"
     command: ["dask-scheduler"]
 
-  base-notebook:
-    build:
-      context: github.com/jupyter/docker-stacks.git#master:base-notebook
-      dockerfile: Dockerfile
-      args:
-        python: "3.8"
-    image: daskdev/base-notebook:lab
-
   worker:
-    build:
-      context: ./base
-      dockerfile: Dockerfile
-    image: daskdev/dask
-    hostname: dask-worker
+    image: daskdev/dask:latest
     command: ["dask-worker", "tcp://scheduler:8786"]
+    # For Docker swarm you can specify multiple workers, this is ignored by `docker-compose up`
+    deploy:
+      replicas: 2
 
   notebook:
-    build:
-      context: ./notebook
-      dockerfile: Dockerfile
-      args:
-        base: daskdev
-        python: "3.8"
-    depends_on:
-      - base-notebook
-    image: daskdev/dask-notebook
-    hostname: notebook
+    image: daskdev/dask-notebook:latest
     ports:
       - "8888:8888"
     environment:


### PR DESCRIPTION
I've shuffled the README around a little to make things clearer and added badges and links to the images on Docker Hub.

The `docker-compose.yml` that is used for building has also grown in complexity over time and I've seen users get confused and try and use that stack for running Dask instead of building it. To solve this I've moved the building stack into a `build` directory and created a new simplified example stack in the root of the project.