### PR TITLE
dask-notebook for accidentally renamed to just notebook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         image:
           - tag: "daskdev/dask"
             context: "./base"
-          - tag: "daskdev/notebook"
+          - tag: "daskdev/dask-notebook"
             context: "./notebook"
 
     steps:
@@ -53,7 +53,7 @@ jobs:
 
       - name: Checkout upstream Jupyter Lab image repo
         uses: actions/checkout@v2
-        if: matrix.image.tag == 'daskdev/notebook'
+        if: matrix.image.tag == 'daskdev/dask-notebook'
         with:
           repository: jupyter/docker-stacks
           ref: master
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build upstream Jupyter Lab image
         uses: docker/build-push-action@v2
-        if: matrix.image.tag == 'daskdev/notebook'
+        if: matrix.image.tag == 'daskdev/dask-notebook'
         with:
           context: ./docker-stacks/base-notebook
           push: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | Image  | Description | Versions |
 | ------------- | ------------- | ------------- |
 | `daskdev/dask`  | Base image to use for Dask scheduler and workers  |   [![](https://img.shields.io/badge/daskdev%2Fdask-2021.8.0--py3.8-blue) ![](https://img.shields.io/badge/daskdev%2Fdask-2021.8.0-blue) ![](https://img.shields.io/badge/daskdev%2Fdask-latest-blue) <br /> ![](https://img.shields.io/badge/daskdev%2Fdask-2021.8.0--py3.9-blue)](https://hub.docker.com/r/daskdev/dask/tags)  |
-| `daskdev/notebook`  | Jupyter Notebook image to use as helper entrypoint  | [![](https://img.shields.io/badge/daskdev%2Fnotebook-2021.8.0--py3.8-blue) ![](https://img.shields.io/badge/daskdev%2Fnotebook-2021.8.0-blue) ![](https://img.shields.io/badge/daskdev%2Fnotebook-latest-blue) <br /> ![](https://img.shields.io/badge/daskdev%2Fnotebook-2021.8.0--py3.9-blue)](https://hub.docker.com/r/daskdev/notebook/tags) |
+| `daskdev/dask-notebook`  | Jupyter Notebook image to use as helper entrypoint  | [![](https://img.shields.io/badge/daskdev%2Fdask--notebook-2021.8.0--py3.8-blue) ![](https://img.shields.io/badge/daskdev%2Fdask--notebook-2021.8.0-blue) ![](https://img.shields.io/badge/daskdev%2Fdask--notebook-latest-blue) <br /> ![](https://img.shields.io/badge/daskdev%2Fdask--notebook-2021.8.0--py3.9-blue)](https://hub.docker.com/r/daskdev/dask-notebook/tags) |
 
 
 ## Example


### PR DESCRIPTION
Looks like in #149 the `daskdev/dask-notebook` image got accidentally renamed to `daskdev/notebook`.

I've fixed the images on Docker Hub manually and this PR puts things right for next time.