### PR TITLE
Losely pin Python and add blosc

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,7 +12,8 @@ ENV DASK_VERSION=${release}
 RUN conda install --yes nomkl cytoolz cmake \
     && conda install --yes mamba \
     && mamba install --yes -c conda-forge \
-    python==${PYTHON_VERSION} \
+    python=${PYTHON_VERSION} \
+    blosc \
     cytoolz \
     dask==${DASK_VERSION} \
     lz4 \


### PR DESCRIPTION
I think by setting something like `python==3.8` we are getting `3.8.0`. If we set `python=3.8` we will get the latest patch release (currently `3.8.10`).

Also adding blosc.

Hopefully this will address the warning in #161.