### PR TITLE
Bump to 2021.8.1 in docker build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      release: "2021.8.0"
+      release: "2021.8.1"
       defaultpython: "3.8"
 
     strategy:


### PR DESCRIPTION
https://github.com/dask/dask-docker/pull/178 updated the `release: XXXX.XX.X` field in `build/docker-compose.yml` but not `.github/workflows/build.yml`. This PR updates `.github/workflows/build.yml` accordingly. 