### PR TITLE
Integrate with jupyterhub launcher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   notebook:
     image: daskdev/dask-notebook:latest
+    command: ["start.sh", "jupyter", "lab"]
     ports:
       - "8888:8888"
     environment:

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -38,6 +38,7 @@ RUN mamba install --yes python=${PYTHON_VERSION} nomkl \
     cachey \
     streamz \
     dask-labextension>=5 \
+    && pip install dask-kubernetes \
     && mamba clean -tipsy \
     && jupyter lab clean \
     && jlpm cache clean \

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -33,4 +33,4 @@ fi
 
 
 # Execute the jupyterlab as specified.
-exec start.sh jupyter lab ${JUPYTERLAB_ARGS}
+exec ${JUPYTERLAB_ARGS}

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -32,5 +32,5 @@ if [ "$EXTRA_PIP_PACKAGES" ]; then
 fi
 
 
-# Execute the jupyterlab as specified.
-exec ${JUPYTERLAB_ARGS}
+# Execute the jupyterlab as specified from either JUPYTERLAB_ARGS or command line args.
+exec ${JUPYTERLAB_ARGS} "$@"


### PR DESCRIPTION
This allows the container to be used from the zero-to-jupyterhub launcher (aka kubespawner).