### PR TITLE
Handle NB_PREFIX

### DIFF
--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -33,4 +33,4 @@ fi
 
 
 # Execute the jupyterlab as specified.
-exec start.sh jupyter lab ${JUPYTERLAB_ARGS}
+exec start.sh jupyter lab --NotebookApp.base_url="${NB_PREFIX:-/}" ${JUPYTERLAB_ARGS}


### PR DESCRIPTION
Some spawning environments such as [the one used in Kubeflow](https://www.kubeflow.org/docs/components/notebooks/container-images/#image-requirements) expect to set an `NB_PREFIX` environment variable when proxying the Jupyter server so that Jupyter handles requests correctly.

Updating the `jupyter lab` command to handle this.