### PR TITLE
Add ghcr.io builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,11 @@ jobs:
         image:
           - tag: "daskdev/dask"
             context: "./base"
+          - tag: "ghcr.io/dask/dask"
+            context: "./base"
           - tag: "daskdev/dask-notebook"
+            context: "./notebook"
+          - tag: "ghcr.io/dask/dask-notebook"
             context: "./notebook"
 
     steps:
@@ -53,7 +57,7 @@ jobs:
 
       - name: Checkout upstream Jupyter Lab image repo
         uses: actions/checkout@v2
-        if: matrix.image.tag == 'daskdev/dask-notebook'
+        if: contains(matrix.image.tag, 'dask-notebook')
         with:
           repository: jupyter/docker-stacks
           ref: master
@@ -61,7 +65,7 @@ jobs:
 
       - name: Build upstream Jupyter Lab image
         uses: docker/build-push-action@v2
-        if: matrix.image.tag == 'daskdev/dask-notebook'
+        if: contains(matrix.image.tag, 'dask-notebook')
         with:
           context: ./docker-stacks/base-notebook
           push: false

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 | Image  | Description | Versions |
 | ------------- | ------------- | ------------- |
-| `daskdev/dask`  | Base image to use for Dask scheduler and workers  |   [![][daskdev-dask-py38-release] ![][daskdev-dask-release] ![][daskdev-dask-latest] <br /> ![][daskdev-dask-py39-release]](https://hub.docker.com/r/daskdev/dask/tags)  |
-| `daskdev/dask-notebook`  | Jupyter Notebook image to use as helper entrypoint  | [![][daskdev-dask-notebook-py38-release] ![][daskdev-dask-notebook-release] ![][daskdev-dask-notebook-latest] <br /> ![][daskdev-dask-notebook-py39-release]](https://hub.docker.com/r/daskdev/dask-notebook/tags) |
+| `ghcr.io/dask/dask`  | Base image to use for Dask scheduler and workers  |   [![][daskdev-dask-py38-release] ![][daskdev-dask-release] ![][daskdev-dask-latest] <br /> ![][daskdev-dask-py39-release]](https://github.com/dask/dask-docker/pkgs/container/dask)  |
+| `ghcr.io/dask/dask-notebook`  | Jupyter Notebook image to use as helper entrypoint  | [![][daskdev-dask-notebook-py38-release] ![][daskdev-dask-notebook-release] ![][daskdev-dask-notebook-latest] <br /> ![][daskdev-dask-notebook-py39-release]](https://github.com/dask/dask-docker/pkgs/container/dask-notebook) |
 
-[daskdev-dask-latest]: https://img.shields.io/badge/daskdev%2Fdask-latest-blue
-[daskdev-dask-release]: https://img.shields.io/badge/daskdev%2Fdask-2022.2.1-blue
-[daskdev-dask-py38-release]: https://img.shields.io/badge/daskdev%2Fdask-2022.2.1--py3.8-blue
-[daskdev-dask-py39-release]: https://img.shields.io/badge/daskdev%2Fdask-2022.2.1--py3.9-blue
-[daskdev-dask-notebook-latest]: https://img.shields.io/badge/daskdev%2Fdask--notebook-latest-blue
-[daskdev-dask-notebook-release]: https://img.shields.io/badge/daskdev%2Fdask--notebook-2022.2.1-blue
-[daskdev-dask-notebook-py38-release]: https://img.shields.io/badge/daskdev%2Fdask--notebook-2022.2.1--py3.8-blue
-[daskdev-dask-notebook-py39-release]: https://img.shields.io/badge/daskdev%2Fdask--notebook-2022.2.1--py3.9-blue
+[daskdev-dask-latest]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-latest-blue
+[daskdev-dask-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.2.1-blue
+[daskdev-dask-py38-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.2.1--py3.8-blue
+[daskdev-dask-py39-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.2.1--py3.9-blue
+[daskdev-dask-notebook-latest]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-latest-blue
+[daskdev-dask-notebook-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.2.1-blue
+[daskdev-dask-notebook-py38-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.2.1--py3.8-blue
+[daskdev-dask-notebook-py39-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.2.1--py3.9-blue
 
 
 ## Example

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
       args:
         release: "2022.2.1"
-    image: ghcr.io/dask:latest
+    image: ghcr.io/dask/dask:latest
     hostname: dask-scheduler
     ports:
       - "8786:8786"
@@ -29,7 +29,7 @@ services:
       args:
         python: "3.8"
         release: "2022.2.1"
-    image: ghcr.io/dask:latest
+    image: ghcr.io/dask/dask:latest
     hostname: dask-worker
     command: ["dask-worker", "tcp://scheduler:8786"]
 
@@ -43,7 +43,7 @@ services:
         release: "2022.2.1"
     depends_on:
       - base-notebook
-    image: ghcr.io/dask-notebook:latest
+    image: ghcr.io/dask/dask/dask-notebook:latest
     hostname: notebook
     ports:
       - "8888:8888"

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
       args:
         release: "2022.2.1"
-    image: daskdev/dask:latest
+    image: ghcr.io/dask:latest
     hostname: dask-scheduler
     ports:
       - "8786:8786"
@@ -29,7 +29,7 @@ services:
       args:
         python: "3.8"
         release: "2022.2.1"
-    image: daskdev/dask:latest
+    image: ghcr.io/dask:latest
     hostname: dask-worker
     command: ["dask-worker", "tcp://scheduler:8786"]
 
@@ -43,7 +43,7 @@ services:
         release: "2022.2.1"
     depends_on:
       - base-notebook
-    image: daskdev/dask-notebook:latest
+    image: ghcr.io/dask-notebook:latest
     hostname: notebook
     ports:
       - "8888:8888"

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         release: "2022.2.1"
     depends_on:
       - base-notebook
-    image: ghcr.io/dask/dask/dask-notebook:latest
+    image: ghcr.io/dask/dask-notebook:latest
     hostname: notebook
     ports:
       - "8888:8888"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       replicas: 2
 
   notebook:
-    image: ghcr.io/dask/dask/dask-notebook:latest
+    image: ghcr.io/dask/dask-notebook:latest
     ports:
       - "8888:8888"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.1"
 
 services:
   scheduler:
-    image: daskdev/dask:latest
+    image: ghcr.io/dask:latest
     hostname: scheduler
     ports:
       - "8786:8786"
@@ -10,14 +10,14 @@ services:
     command: ["dask-scheduler"]
 
   worker:
-    image: daskdev/dask:latest
+    image: ghcr.io/dask:latest
     command: ["dask-worker", "tcp://scheduler:8786"]
     # For Docker swarm you can specify multiple workers, this is ignored by `docker-compose up`
     deploy:
       replicas: 2
 
   notebook:
-    image: daskdev/dask-notebook:latest
+    image: ghcr.io/dask-notebook:latest
     ports:
       - "8888:8888"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.1"
 
 services:
   scheduler:
-    image: ghcr.io/dask:latest
+    image: ghcr.io/dask/dask:latest
     hostname: scheduler
     ports:
       - "8786:8786"
@@ -10,14 +10,14 @@ services:
     command: ["dask-scheduler"]
 
   worker:
-    image: ghcr.io/dask:latest
+    image: ghcr.io/dask/dask:latest
     command: ["dask-worker", "tcp://scheduler:8786"]
     # For Docker swarm you can specify multiple workers, this is ignored by `docker-compose up`
     deploy:
       replicas: 2
 
   notebook:
-    image: ghcr.io/dask-notebook:latest
+    image: ghcr.io/dask/dask/dask-notebook:latest
     ports:
       - "8888:8888"
     environment:


### PR DESCRIPTION
Closes #177.

This PR updates the build CI to publish images to the GitHub Container Registry in addition to Docker Hub.

It also updates the documentation to mention the `ghcr.io` images by default as part of the deprecation of Docker Hub. Eventually we may choose to remove Docker Hub all together.

I have already manually pushed the `2022.2.1` images to `ghcr.io` so folks can get started with them right away.