### PR TITLE
Unpin dependencies

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,8 +16,8 @@ RUN conda install --yes -c conda-forge nomkl cytoolz cmake mamba python=${PYTHON
     cytoolz \
     dask==${DASK_VERSION} \
     lz4 \
-    numpy==1.21.1 \
-    pandas==1.3.0 \
+    numpy \
+    pandas \
     tini==0.18.0 \
     cachey \
     streamz \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -32,8 +32,8 @@ RUN mamba install --yes python=${PYTHON_VERSION} nomkl \
     cytoolz \
     dask==${DASK_VERSION} \
     lz4 \
-    numpy==1.21.1 \
-    pandas==1.3.0 \
+    numpy \
+    pandas \
     ipywidgets \
     cachey \
     streamz \


### PR DESCRIPTION
Numpy and Pandas have been pinned in the docker images for a long time. Given that we pin the Dask version I would hope that conda can resolve this correctly and we shouldn't need further pinning. Given some issues raised by @charlesbluca I'm keen to unpin here.

cc @dask/maintenance  for thoughts