### PR TITLE
Fix autotag action

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: butlerlogic/action-autotag@1.1.2
+      - uses: butlerlogic/action-autotag@stable
         if: github.repository == 'dask/dask-docker'
         with:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           strategy: regex
           regex_pattern: '\s*\[?.*release\]?: "?.*(\d{4}\.\d{1,2}\.\d+).*"?'
+          root: ".github/workflows/build.yml"


### PR DESCRIPTION
xref #180

I noticed in the `2022.3.0` release the tag was not created. I think this was because the autotag action is broken and @jrbourbeau has been manually creating the tag. This PR should fix up the action so that it works as expected.

cc @jsignell 