### PR TITLE
Use bot token to trigger downstream workflows

### DIFF
--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DASK_BOT_TOKEN }}
           commit-message: "Update Dask version to ${{ steps.latest_version.outputs.version }}"
           title: "Update Dask version to ${{ steps.latest_version.outputs.version }}"
           reviewers: "jacobtomlinson"


### PR DESCRIPTION
As noted in #180 when the automatic PR is raised it doesn't trigger the downstream workflows and an empty commit needs to be pushed. This is because the `GITHUB_TOKEN` doesn't trigger workflows to avoid infinite actions loops.

To work around this we have the @dask-bot user and a PAT available to some repos called `DASK_BOT_TOKEN`.

This PR updates the workflow to use the bot token instead of the actions token.