### PR TITLE
Use bot token for autotagging

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: butlerlogic/action-autotag@stable
         if: github.repository == 'dask/dask-docker'
         with:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.DASK_BOT_TOKEN }}"
           strategy: regex
           regex_pattern: '\s*\[?.*release\]?: "?.*(\d{4}\.\d{1,2}\.\d+).*"?'
           root: ".github/workflows/build.yml"


### PR DESCRIPTION
We have an actions workflow to automatically build and push images when tags are created. However this doesn't get triggered when the tag is created by a workflow using the `GITHUB_TOKEN` so switching this to the `DASK_BOT_TOKEN` too.