### PR TITLE
Trigger images builds on tag pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
   pull_request:
 
 jobs:


### PR DESCRIPTION
With #214, we accidentally made it so images would not be built/published on new/updated tags.

This PR add the `on.push.tags` condition to the image building workflow so this is no longer the case.