### PR TITLE
Add `USE_MAMBA` option for conda installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following environment variables are supported for both the base and notebook
 * `$EXTRA_APT_PACKAGES` - Space separated list of additional system packages to install with apt.
 * `$EXTRA_CONDA_PACKAGES` - Space separated list of additional packages to install with conda.
 * `$EXTRA_PIP_PACKAGES` - Space separated list of additional python packages to install with pip.
+* `$USE_MAMBA` - Boolean controlling whether to use conda or mamba to install `$EXTRA_CONDA_PACKAGES`.
 
 The notebook image supports the following additional environment variables:
 

--- a/base/prepare.sh
+++ b/base/prepare.sh
@@ -9,16 +9,23 @@ if [ "$EXTRA_APT_PACKAGES" ]; then
     apt install -y $EXTRA_APT_PACKAGES
 fi
 
+if [ "$USE_MAMBA" == "true" ]; then
+    echo "USE_MAMBA enabled. Using mamba for all conda operations"
+    CONDA_BIN="/opt/conda/bin/mamba"
+else
+    CONDA_BIN="/opt/conda/bin/conda"
+fi
+
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
-    /opt/conda/bin/conda env update -f /opt/app/environment.yml
+    $CONDA_BIN env update -f /opt/app/environment.yml
 else
     echo "no environment.yml"
 fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install -y $EXTRA_CONDA_PACKAGES
+    $CONDA_BIN install -y $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -9,16 +9,23 @@ if [ "$EXTRA_APT_PACKAGES" ]; then
     sudo apt-get install -y $EXTRA_APT_PACKAGES
 fi
 
+if [ "$USE_MAMBA" == "true" ]; then
+    echo "USE_MAMBA enabled. Using mamba for all conda operations"
+    CONDA_BIN="/opt/conda/bin/mamba"
+else
+    CONDA_BIN="/opt/conda/bin/conda"
+fi
+
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
-    /opt/conda/bin/conda env update -f /opt/app/environment.yml
+    $CONDA_BIN env update -f /opt/app/environment.yml
 else
     echo "no environment.yml"
 fi
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install -y $EXTRA_CONDA_PACKAGES
+    $CONDA_BIN install -y $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then


### PR DESCRIPTION
Adds support for the `USE_MAMBA` environment variable, which controls whether or not to use `mamba` for the relevant Conda installs when building a container.

Closes #215