### PR TITLE
Always use `mamba` for conda installs in Dockerfiles

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_CONTAINER=condaforge/miniforge3:4.11.0-4
+ARG BASE_CONTAINER=condaforge/mambaforge:latest
 FROM $BASE_CONTAINER
 
 ARG python=3.8
@@ -10,8 +10,10 @@ ENV PATH /opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${python}
 ENV DASK_VERSION=${release}
 
-RUN conda install --yes -c conda-forge nomkl cytoolz cmake mamba python=${PYTHON_VERSION} \
-    && mamba install --yes -c conda-forge \
+RUN mamba install -y \
+    python=${PYTHON_VERSION} \
+    nomkl \
+    cmake \
     python-blosc \
     cytoolz \
     dask==${DASK_VERSION} \
@@ -20,8 +22,9 @@ RUN conda install --yes -c conda-forge nomkl cytoolz cmake mamba python=${PYTHON
     pandas \
     tini==0.18.0 \
     cachey \
-    streamz \
-    && mamba clean -tipsy \
+    streamz
+
+RUN mamba clean -tipsy \
     && find /opt/conda/ -type f,l -name '*.a' -delete \
     && find /opt/conda/ -type f,l -name '*.pyc' -delete \
     && find /opt/conda/ -type f,l -name '*.js.map' -delete \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,9 +22,8 @@ RUN mamba install -y \
     pandas \
     tini==0.18.0 \
     cachey \
-    streamz
-
-RUN mamba clean -tipsy \
+    streamz \
+    && mamba clean -tipsy \
     && find /opt/conda/ -type f,l -name '*.a' -delete \
     && find /opt/conda/ -type f,l -name '*.pyc' -delete \
     && find /opt/conda/ -type f,l -name '*.js.map' -delete \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -39,7 +39,7 @@ RUN mamba install -y \
     ipywidgets \
     cachey \
     streamz \
-    dask-labextension>=5
+    "dask-labextension>=5"
 
 RUN mamba clean -tipsy \
     && jupyter lab clean \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -27,9 +27,9 @@ RUN MAGICARCH=$(dpkg --print-architecture) && \
 
 USER $NB_USER
 
-RUN conda install mamba -n base -c conda-forge --yes
-RUN mamba install --yes python=${PYTHON_VERSION} nomkl \
-    && mamba install --yes \
+RUN mamba install -y \
+    python=${PYTHON_VERSION} \
+    nomkl \
     python-blosc \
     cytoolz \
     dask==${DASK_VERSION} \
@@ -39,8 +39,9 @@ RUN mamba install --yes python=${PYTHON_VERSION} nomkl \
     ipywidgets \
     cachey \
     streamz \
-    dask-labextension>=5 \
-    && mamba clean -tipsy \
+    dask-labextension>=5
+
+RUN mamba clean -tipsy \
     && jupyter lab clean \
     && jlpm cache clean \
     && npm cache clean --force \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -39,9 +39,8 @@ RUN mamba install -y \
     ipywidgets \
     cachey \
     streamz \
-    "dask-labextension>=5"
-
-RUN mamba clean -tipsy \
+    "dask-labextension>=5" \
+    && mamba clean -tipsy \
     && jupyter lab clean \
     && jlpm cache clean \
     && npm cache clean --force \


### PR DESCRIPTION
Since our `dask-notebook` images are already running with a Mambaforge installation, I figured we could make this consistent in the `dask` images and remove all uses of `conda` since we no longer need to install `mamba`.