### PR TITLE
Build and publish containers on all commits

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -6,14 +6,19 @@ on:
       - main
 
 jobs:
-  build:
+  autotag:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: butlerlogic/action-autotag@stable
-        if: github.repository == 'dask/dask-docker'
+      - name: Parse current build.yml for release version
+        id: yaml
+        uses: the-coding-turtle/ga-yaml-parser@v0.1.1
         with:
-          GITHUB_TOKEN: "${{ secrets.DASK_BOT_TOKEN }}"
-          strategy: regex
-          regex_pattern: '\s*\[?.*release\]?: "?.*(\d{4}\.\d{1,2}\.\d+).*"?'
-          root: ".github/workflows/build.yml"
+          file: .github/workflows/build.yml
+          key: jobs_docker_env_release
+      - name: Create or update release tag
+        uses: rickstaa/action-create-tag@v1.2.2
+        with:
+          tag: ${{ steps.yaml.outputs.result }}
+          message: Version ${{ steps.yaml.outputs.result }}
+          force_push_tag: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
   pull_request:
 
 jobs:
@@ -51,14 +49,14 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: github.repository == 'dask/dask-docker' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.repository == 'dask/dask-docker' && github.event_name == 'push'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
-        if: github.repository == 'dask/dask-docker' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.repository == 'dask/dask-docker' && github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -102,7 +100,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.image.context }}
-          push: ${{ github.repository == 'dask/dask-docker' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+          push: ${{ github.repository == 'dask/dask-docker' && github.event_name == 'push' }}
           platforms: linux/amd64
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |


### PR DESCRIPTION
This PR changes the tagging / publishing CI so that on all commits to `main`:

- new containers are built and published
- the trigger commit is force pushed to the release tag specified in `build.yml`

Closes #223