### PR TITLE
Publish to `dev` tag on all commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,14 +51,14 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: github.repository == 'dask/dask-docker' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.repository == 'dask/dask-docker' && github.event_name == 'push'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
-        if: github.repository == 'dask/dask-docker' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.repository == 'dask/dask-docker' && github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -69,12 +69,22 @@ jobs:
         env:
           image: ${{ matrix.image.tag }}
           python: ${{ matrix.python }}
+          stable: ${{ startsWith(github.ref, 'refs/tags') }}
         run: |
-          tag="${image}:${release}-py${python}"
-          tags=$tag
-          if [ "$python" == "$defaultpython" ]; then
-            tags=${image}:latest,${image}:${release},$tags
+          if [ "$stable" == "true" ]; then
+            tag="${image}:${release}-py${python}"
+            tags=$tag
+            if [ "$python" == "$defaultpython" ]; then
+              tags=${image}:latest,${image}:${release},$tags
+            fi
+          else
+            tag="${image}:dev-${python}"
+            tags=$tag
+            if [ "$python" == "$defaultpython" ]; then
+              tags=${image}:dev,$tags
+            fi
           fi
+
           echo "::set-output name=tags::${tags}"
           echo "::set-output name=tag::${tag}"
 
@@ -102,7 +112,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.image.context }}
-          push: ${{ github.repository == 'dask/dask-docker' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+          push: ${{ github.repository == 'dask/dask-docker' && github.event_name == 'push' }}
           platforms: linux/amd64
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
               tags=${image}:latest,${image}:${release},$tags
             fi
           else
-            tag="${image}:dev-${python}"
+            tag="${image}:dev-py${python}"
             tags=$tag
             if [ "$python" == "$defaultpython" ]; then
               tags=${image}:dev,$tags


### PR DESCRIPTION
This PR makes it so that all commits to `main` will publish the following images:

- `dev-py<py_version>` - images built using the latest source, with `python=$py_version`
- `dev` - alias for the `dev-py<py_version>` corresponding to the `defaultpython` set in the Docker build workflow

Closes #223