### PR TITLE
Add `NIGHTLY_DASK` environment variable for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following environment variables are supported for both the base and notebook
 * `$EXTRA_CONDA_PACKAGES` - Space separated list of additional packages to install with conda.
 * `$EXTRA_PIP_PACKAGES` - Space separated list of additional python packages to install with pip.
 * `$USE_MAMBA` - Boolean controlling whether to use conda or mamba to install `$EXTRA_CONDA_PACKAGES`.
+* `$NIGHTLY_DASK` - Boolean controlling whether or not to install nightly versions of Dask/Distributed.
 
 The notebook image supports the following additional environment variables:
 

--- a/base/prepare.sh
+++ b/base/prepare.sh
@@ -16,6 +16,11 @@ else
     CONDA_BIN="/opt/conda/bin/conda"
 fi
 
+if [ "$NIGHTLY_DASK" == "true" ]; then
+    echo "NIGHTLY_DASK enabled. Installing latest Dask nightly conda packages."
+    $CONDA_BIN update -c dask/label/dev -y dask
+if
+
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
     $CONDA_BIN env update -f /opt/app/environment.yml

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -16,6 +16,11 @@ else
     CONDA_BIN="/opt/conda/bin/conda"
 fi
 
+if [ "$NIGHTLY_DASK" == "true" ]; then
+    echo "NIGHTLY_DASK enabled. Installing latest Dask nightly conda packages."
+    $CONDA_BIN update -c dask/label/dev -y dask
+if
+
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"
     $CONDA_BIN env update -f /opt/app/environment.yml


### PR DESCRIPTION
Adds a `NIGHTLY_DASK` option, which when enabled updates Dask/Distributed using `dask/label/dev`.

Note that as pointed out in https://github.com/dask/dask-docker/issues/223#issuecomment-1121215350, it should already be possible to do this through `EXTRA_CONDA_PACKAGES`, so this is more of a convenience than a new feature.