### PR TITLE
Disable buildkit when building images

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Docker compose provides an easy way to building all the images with the right co
 ```bash
 cd build
 
+# Use legacy builder as buildkit still doesn't support subdirectories when building from git repos
+export DOCKER_BUILDKIT=0
+export COMPOSE_DOCKER_CLI_BUILD=0
+
 docker-compose build
 
 # Just build one image e.g. notebook


### PR DESCRIPTION
Closes #236 

To build the base notebook image we are building from a git repo that uses a subdirectory. Sadly `buildkit` still doesn't support this despite now being the default builder, so updating the instructions here to continue using the legacy builder.

_Note that we don't use these instructions for building in CI, this only affects users building locally._