### PR TITLE
Use `main` branch with `jupyter/docker-stacks`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         if: contains(matrix.image.tag, 'dask-notebook')
         with:
           repository: jupyter/docker-stacks
-          ref: master
+          ref: main
           path: docker-stacks
 
       - name: Build upstream Jupyter Lab image

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   base-notebook:
     build:
-      context: github.com/jupyter/docker-stacks.git#master:base-notebook
+      context: github.com/jupyter/docker-stacks.git#main:base-notebook
       dockerfile: Dockerfile
       args:
         PYTHON_VERSION: "3.8"


### PR DESCRIPTION
Recently `jupyter/docker-stacks` switched the name of their default branch to `main` (xref https://github.com/jupyter/docker-stacks/pull/1741). This PR makes the corresponding update here so we don't encounter `git` fetch errors like we were seeing in [this CI build](https://github.com/dask/dask-docker/runs/7260101545?check_suite_focus=true) 