### PR TITLE
Patch upstream `base-notebook` Dockerfile to resolve mamba issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,13 @@ jobs:
           ref: main
           path: docker-stacks
 
+      # FIXME: remove once jupyter/docker-stacks#1810 is resolved
+      - name: Patch upstream Jupyter Lab image repo
+        if: contains(matrix.image.tag, 'dask-notebook')
+        run: |
+          cd docker-stacks
+          git apply ../notebook/fix-upstream-jupyter.patch
+
       - name: Build upstream Jupyter Lab image
         uses: docker/build-push-action@v2
         if: contains(matrix.image.tag, 'dask-notebook')

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ../base
       dockerfile: Dockerfile
       args:
-        release: "2022.10.0"
+        release: "2022.10.1"
     image: ghcr.io/dask/dask:latest
     hostname: dask-scheduler
     ports:
@@ -28,7 +28,7 @@ services:
       dockerfile: Dockerfile
       args:
         python: "3.8"
-        release: "2022.10.0"
+        release: "2022.10.1"
     image: ghcr.io/dask/dask:latest
     hostname: dask-worker
     command: ["dask-worker", "tcp://scheduler:8786"]
@@ -40,7 +40,7 @@ services:
       args:
         base: daskdev
         python: "3.8"
-        release: "2022.10.0"
+        release: "2022.10.1"
     depends_on:
       - base-notebook
     image: ghcr.io/dask/dask-notebook:latest

--- a/notebook/fix-upstream-jupyter.patch
+++ b/notebook/fix-upstream-jupyter.patch
@@ -1,0 +1,12 @@
+diff --git a/base-notebook/Dockerfile b/base-notebook/Dockerfile
+index 9a3a836..c67c054 100644
+--- a/base-notebook/Dockerfile
++++ b/base-notebook/Dockerfile
+@@ -126,6 +126,7 @@ RUN set -x && \
+         'notebook' \
+         'jupyterhub' \
+         'jupyterlab' && \
++    conda update -y -c conda-forge mamba && \
+     rm micromamba && \
+     # Pin major.minor version of python
+     mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \


### PR DESCRIPTION
Not sure how close we are to resolution in https://github.com/jupyter/docker-stacks/issues/1810, so this PR attempts to resolve the issue locally by patching the impacted `base-notebook` Dockerfile to update `mamba` before proceeding with the build.