### PR TITLE
Update Dask version to 2022.11.0, switch from `base-notebook` to `docker-stacks-foundation`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,11 +100,11 @@ jobs:
         uses: docker/build-push-action@v2
         if: contains(matrix.image.tag, 'dask-notebook')
         with:
-          context: ./docker-stacks/base-notebook
+          context: ./docker-stacks/docker-stacks-foundation
           push: false
           load: true
           platforms: linux/amd64
-          tags: daskdev/base-notebook:lab
+          tags: daskdev/docker-stacks-foundation:lab
           build-args: |
             PYTHON_VERSION=${{ matrix.python }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      release: "2022.10.2"
+      release: "2022.11.0"
       defaultpython: "3.8"
 
     strategy:

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 | `ghcr.io/dask/dask-notebook`  | Jupyter Notebook image to use as helper entrypoint  | [![][daskdev-dask-notebook-py38-release] ![][daskdev-dask-notebook-release] ![][daskdev-dask-notebook-latest] <br /> ![][daskdev-dask-notebook-py39-release]](https://github.com/dask/dask-docker/pkgs/container/dask-notebook) |
 
 [daskdev-dask-latest]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-latest-blue
-[daskdev-dask-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.10.2-blue
-[daskdev-dask-py38-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.10.2--py3.8-blue
-[daskdev-dask-py39-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.10.2--py3.9-blue
+[daskdev-dask-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.11.0-blue
+[daskdev-dask-py38-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.11.0--py3.8-blue
+[daskdev-dask-py39-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2022.11.0--py3.9-blue
 [daskdev-dask-notebook-latest]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-latest-blue
-[daskdev-dask-notebook-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.10.2-blue
-[daskdev-dask-notebook-py38-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.10.2--py3.8-blue
-[daskdev-dask-notebook-py39-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.10.2--py3.9-blue
+[daskdev-dask-notebook-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.11.0-blue
+[daskdev-dask-notebook-py38-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.11.0--py3.8-blue
+[daskdev-dask-notebook-py39-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2022.11.0--py3.9-blue
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ docker-compose build notebook
 
 ### Cross building
 
-The images can be cross-built using `docker buildx bake`. However buildx bake does not listen to `depends_on` (since in theory that is only a runtime not a build time constraint https://github.com/docker/buildx/issues/447). To work around this we first need to build the "base-notebook" image.
+The images can be cross-built using `docker buildx bake`. However buildx bake does not listen to `depends_on` (since in theory that is only a runtime not a build time constraint https://github.com/docker/buildx/issues/447). To work around this we first need to build the "docker-stacks-foundation" image.
 
 ```bash
 cd build
 
 # If you have permission to push to daskdev/
-docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --push base-notebook
+docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --push docker-stacks-foundation
 docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --push
 
 # If you don'tset DOCKERUSER to your dockerhub username.
 export DOCKERUSER=holdenk
-docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --set base-notebook.tags.image=${DOCKERUSER}/base-notebook:lab-py38 --push base-notebook
-docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --set scheduler.tags=${DOCKERUSER}/dask --set worker.tags=${DOCKERUSER}/dask --set notebook.tags=${DOCKERUSER}/dask-notebook --set base-notebook.tags=${DOCKERUSER}/base-notebook:lab-py38 --set notebook.args.base=${DOCKERUSER} --push
+docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --set docker-stacks-foundation.tags.image=${DOCKERUSER}/docker-stacks-foundation:lab-py38 --push docker-stacks-foundation
+docker buildx bake --progress=plain --set *.platform=linux/arm64,linux/amd64 --set scheduler.tags=${DOCKERUSER}/dask --set worker.tags=${DOCKERUSER}/dask --set notebook.tags=${DOCKERUSER}/dask-notebook --set docker-stacks-foundation.tags=${DOCKERUSER}/docker-stacks-foundation:lab-py38 --set notebook.args.base=${DOCKERUSER} --push
 ```
 
 ## Releasing

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -14,13 +14,13 @@ services:
       - "8787:8787"
     command: ["dask-scheduler"]
 
-  base-notebook:
+  docker-stacks-foundation:
     build:
-      context: github.com/jupyter/docker-stacks.git#main:base-notebook
+      context: github.com/jupyter/docker-stacks.git#main:docker-stacks-foundation
       dockerfile: Dockerfile
       args:
         PYTHON_VERSION: "3.8"
-    image: daskdev/base-notebook:lab
+    image: daskdev/docker-stacks-foundation:lab
 
   worker:
     build:
@@ -42,7 +42,7 @@ services:
         python: "3.8"
         release: "2022.11.0"
     depends_on:
-      - base-notebook
+      - docker-stacks-foundation
     image: ghcr.io/dask/dask-notebook:latest
     hostname: notebook
     ports:

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ../base
       dockerfile: Dockerfile
       args:
-        release: "2022.10.2"
+        release: "2022.11.0"
     image: ghcr.io/dask/dask:latest
     hostname: dask-scheduler
     ports:
@@ -28,7 +28,7 @@ services:
       dockerfile: Dockerfile
       args:
         python: "3.8"
-        release: "2022.10.2"
+        release: "2022.11.0"
     image: ghcr.io/dask/dask:latest
     hostname: dask-worker
     command: ["dask-worker", "tcp://scheduler:8786"]
@@ -40,7 +40,7 @@ services:
       args:
         base: daskdev
         python: "3.8"
-        release: "2022.10.2"
+        release: "2022.11.0"
     depends_on:
       - base-notebook
     image: ghcr.io/dask/dask-notebook:latest

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,6 +1,6 @@
 ARG base
 
-FROM $base/base-notebook:lab
+FROM $base/docker-stacks-foundation:lab
 
 ARG release
 ARG python

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -39,14 +39,10 @@ RUN mamba install -y \
     ipywidgets \
     cachey \
     streamz \
-    notebook \
-    jupyterhub \
     jupyterlab \
     "dask-labextension>=5" \
     && mamba clean -tipy \
     && jupyter lab clean \
-    && jlpm cache clean \
-    && npm cache clean --force \
     && find /opt/conda/ -type f,l -name '*.a' -delete \
     && find /opt/conda/ -type f,l -name '*.pyc' -delete \
     && find /opt/conda/ -type f,l -name '*.js.map' -delete \
@@ -55,7 +51,15 @@ RUN mamba install -y \
 
 EXPOSE 8888
 
+# jupyter server config pulled from upstream `base-notebook`
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/main/base-notebook/jupyter_server_config.py /etc/jupyter/jupyter_server_config.py
+
 USER root
+
+# legacy jupyter notebook server support pulled from upstream `base-notebook`
+RUN sed -re "s/c.ServerApp/c.NotebookApp/g" \
+    /etc/jupyter/jupyter_server_config.py > /etc/jupyter/jupyter_notebook_config.py && \
+    fix-permissions /etc/jupyter/
 
 # Create the /opt/app directory, and assert that Jupyter's NB_UID/NB_GID values
 # haven't changed.
@@ -69,6 +73,11 @@ RUN mkdir /opt/app \
 # in the `--chown` statement, so we need to hardcode these values.
 COPY --chown=1000:100 examples/ /home/$NB_USER/examples
 COPY prepare.sh /usr/bin/prepare.sh
+
+# HEALTHCHECK pulled from upstream `base-notebook`
+HEALTHCHECK  --interval=15s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -O- --no-verbose --tries=1 --no-check-certificate \
+    http${GEN_CERT:+s}://localhost:8888${JUPYTERHUB_SERVICE_PREFIX:-/}api || exit 1
 
 USER $NB_USER
 

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -39,6 +39,9 @@ RUN mamba install -y \
     ipywidgets \
     cachey \
     streamz \
+    notebook \
+    jupyterhub \
+    jupyterlab \
     "dask-labextension>=5" \
     && mamba clean -tipy \
     && jupyter lab clean \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -42,6 +42,7 @@ RUN mamba install -y \
     "dask-labextension>=5" \
     && mamba clean -tipy \
     && jupyter lab clean \
+    && jlpm cache clean \
     && npm cache clean --force \
     && find /opt/conda/ -type f,l -name '*.a' -delete \
     && find /opt/conda/ -type f,l -name '*.pyc' -delete \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -42,7 +42,6 @@ RUN mamba install -y \
     "dask-labextension>=5" \
     && mamba clean -tipy \
     && jupyter lab clean \
-    && jlpm cache clean \
     && npm cache clean --force \
     && find /opt/conda/ -type f,l -name '*.a' -delete \
     && find /opt/conda/ -type f,l -name '*.pyc' -delete \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -53,6 +53,8 @@ RUN mamba install -y \
     && (find /opt/conda/lib/python*/site-packages/bokeh/server/static -type f,l -name '*.js' -not -name '*.min.js' -delete || echo "no bokeh static files to cleanup") \
     && rm -rf /opt/conda/pkgs
 
+EXPOSE 8888
+
 USER root
 
 # Create the /opt/app directory, and assert that Jupyter's NB_UID/NB_GID values


### PR DESCRIPTION
A new Dask version has been detected.

Updated Dockerfiles to use `2022.11.0`.

Also modified our notebook images / build process to now derive from `docker-stacks-foundation` to account for https://github.com/jupyter/docker-stacks/pull/1825.