### PR TITLE
Add Python 3.11 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         image:
           - tag: "daskdev/dask"
             context: "./base"


### PR DESCRIPTION
We have support for Python 3.11 now, so let's add corresponding docker images 

cc @charlesbluca @jacobtomlinson 