### PR TITLE
Retry installing Container Canary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Container Canary
         run: |
           LATEST_RELEASE=$(curl --retry 6 --retry-delay 10 -s https://api.github.com/repos/NVIDIA/container-canary/releases/latest | jq -r ".assets[] | select(.name | test(\"canary_linux_amd64$\")) | .browser_download_url")
-          curl -sSL $LATEST_RELEASE > /usr/local/bin/canary
+          curl --retry 6 --retry-delay 10 -sSL $LATEST_RELEASE > /usr/local/bin/canary
           chmod +x /usr/local/bin/canary
           canary version
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Container Canary
         run: |
-          LATEST_RELEASE=$(curl -s https://api.github.com/repos/NVIDIA/container-canary/releases/latest | jq -r ".assets[] | select(.name | test(\"canary_linux_amd64$\")) | .browser_download_url")
+          LATEST_RELEASE=$(curl --retry 6 --retry-delay 10 -s https://api.github.com/repos/NVIDIA/container-canary/releases/latest | jq -r ".assets[] | select(.name | test(\"canary_linux_amd64$\")) | .browser_download_url")
           curl -sSL $LATEST_RELEASE > /usr/local/bin/canary
           chmod +x /usr/local/bin/canary
           canary version


### PR DESCRIPTION
Installing things from GitHub releases has been flaky recently due to frequent API outages. Added retry flags suggested by @jrbourbeau. 

This tells curl to retry every 10 seconds for one minute. 

 Closes #280 