### PR TITLE
Allow overriding the notebook command

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -82,3 +82,4 @@ HEALTHCHECK  --interval=15s --timeout=3s --start-period=5s --retries=3 \
 USER $NB_USER
 
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]
+CMD ["jupyter", "lab", '--NotebookApp.base_url="${NB_PREFIX:-/}"', '${JUPYTERLAB_ARGS}']

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -35,4 +35,4 @@ fi
 
 
 # Execute the jupyterlab as specified.
-exec start.sh jupyter lab --NotebookApp.base_url="${NB_PREFIX:-/}" ${JUPYTERLAB_ARGS}
+exec start.sh $@


### PR DESCRIPTION
Currently, the `dask-notebook` container starts Jupyter during the `ENTRYPOINT` and never executes the `CMD`.

You may want to do something like `dask scheduler --jupyter ...` instead of `jupyter lab ...` but that is not possible right now. This change moves the Jupyter command into the `CMD` which allows overriding at runtime.