### PR TITLE
Pin `butlerlogic/action-autotag` to 1.1.2 release

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: butlerlogic/action-autotag@stable
+      - uses: butlerlogic/action-autotag@1.1.2
         if: github.repository == 'dask/dask-docker'
         with:
           GITHUB_TOKEN: "${{ secrets.DASK_BOT_TOKEN }}"


### PR DESCRIPTION
A possible temporary workaround as suggested in https://github.com/ButlerLogic/action-autotag/issues/46 and https://github.com/ButlerLogic/action-autotag/issues/45#issuecomment-1825726927

cc @hendrikmakait @jacobtomlinson @charlesbluca 