### PR TITLE
Bump to the latest release of jacobtomlinson/gha-anaconda-package-version

### DIFF
--- a/.github/workflows/watch-conda-forge.yml
+++ b/.github/workflows/watch-conda-forge.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get latest Dask version
         id: latest_version
-        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.4
         with:
           org: "conda-forge"
           package: "dask"


### PR DESCRIPTION
I fixed up some issues in `jacobtomlinson/gha-anaconda-package-version`. This PR bumps to the latest release here.