### PR TITLE
[RFC] Bakefile Multi Arch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,20 +16,6 @@ jobs:
       release: "2024.9.1"
       defaultpython: "3.10"
 
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ["3.10", "3.11", "3.12"]
-        image:
-          - tag: "daskdev/dask"
-            context: "./base"
-          - tag: "ghcr.io/dask/dask"
-            context: "./base"
-          - tag: "daskdev/dask-notebook"
-            context: "./notebook"
-          - tag: "ghcr.io/dask/dask-notebook"
-            context: "./notebook"
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -42,83 +28,39 @@ jobs:
         with:
           driver: docker
 
-      - name: Install Container Canary
-        run: |
-          LATEST_RELEASE=$(curl --retry 6 --retry-delay 10 -s https://api.github.com/repos/NVIDIA/container-canary/releases/latest | jq -r ".assets[] | select(.name | test(\"canary_linux_amd64$\")) | .browser_download_url")
-          curl --retry 6 --retry-delay 10 -sSL $LATEST_RELEASE > /usr/local/bin/canary
-          chmod +x /usr/local/bin/canary
-          canary version
+      #- name: Install Container Canary
+      #  run: |
+      #    LATEST_RELEASE=$(curl --retry 6 --retry-delay 10 -s https://api.github.com/repos/NVIDIA/container-canary/releases/latest | jq -r ".assets[] | select(.name | test(\"canary_linux_amd64$\")) | .browser_download_url")
+      #    curl --retry 6 --retry-delay 10 -sSL $LATEST_RELEASE > /usr/local/bin/canary
+      #    chmod +x /usr/local/bin/canary
+      #    canary version
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        if: github.repository == 'dask/dask-docker' && github.event_name == 'push'
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      #- name: Login to DockerHub
+      #  uses: docker/login-action@v1
+      #  if: github.repository == 'dask/dask-docker' && github.event_name == 'push'
+      #  with:
+      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #    password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
-        if: github.repository == 'dask/dask-docker' && github.event_name == 'push'
+      #  if: github.repository == 'dask/dask-docker' && github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate tags
-        id: tags
-        env:
-          image: ${{ matrix.image.tag }}
-          python: ${{ matrix.python }}
-          stable: ${{ startsWith(github.ref, 'refs/tags') }}
-        run: |
-          if [ "$stable" == "true" ]; then
-            tag="${image}:${release}-py${python}"
-            tags=${image}:latest-py${python},$tag
-            if [ "$python" == "$defaultpython" ]; then
-              tags=${image}:latest,${image}:${release},$tags
-            fi
-          else
-            tag="${image}:dev-py${python}"
-            tags=$tag
-            if [ "$python" == "$defaultpython" ]; then
-              tags=${image}:dev,$tags
-            fi
-          fi
-
-          echo "tags=${tags}" >> $GITHUB_OUTPUT
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-
-      - name: Checkout upstream Jupyter Lab image repo
-        uses: actions/checkout@v2
-        if: contains(matrix.image.tag, 'dask-notebook')
-        with:
-          repository: jupyter/docker-stacks
-          ref: main
-          path: docker-stacks
-
-      - name: Build upstream Jupyter Lab image
-        uses: docker/build-push-action@v2
-        if: contains(matrix.image.tag, 'dask-notebook')
-        with:
-          context: ./docker-stacks/images/docker-stacks-foundation
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: daskdev/docker-stacks-foundation:lab
-          build-args: |
-            PYTHON_VERSION=${{ matrix.python }}
-
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/bake-action@v4
         with:
-          context: ${{ matrix.image.context }}
-          push: ${{ github.repository == 'dask/dask-docker' && github.event_name == 'push' }}
-          platforms: linux/amd64
-          tags: ${{ steps.tags.outputs.tags }}
-          build-args: |
-            python=${{ matrix.python }}
-            release=${{ env.release }}
-            base=daskdev
+          push: true
+          targets: dask
+          files: bakefile.hcl
+        env:
+          STABLE: ${{ startsWith(github.ref, 'refs/tags') }}
+          RELEASE: ${{ env.release }}
+          DEFAULT_PY_VERSION: ${{ env.defaultpython }}
+
 
       - name: Validate Jupyter Lab image for Binder
         if: contains(matrix.image.tag, 'dask-notebook')
@@ -128,5 +70,5 @@ jobs:
         if: contains(matrix.image.tag, 'dask-notebook')
         run: canary validate --file https://github.com/NVIDIA/container-canary/raw/main/examples/kubeflow.yaml ${{ steps.tags.outputs.tag }}
 
-      - name: Report
-        run: echo Built ${{ steps.tags.outputs.tags }}
+      #- name: Report
+      #  run: echo Built ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,9 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver: docker
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       #- name: Install Container Canary
       #  run: |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+build-docker:
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker buildx create --name dask-builder || true
+	docker buildx bake --file bakefile.hcl --builder=dask-builder dask
+
+print-docker:
+	docker buildx bake --file bakefile.hcl dask --print

--- a/bakefile.hcl
+++ b/bakefile.hcl
@@ -133,7 +133,7 @@ target "notebook" {
         baseapp = "target:notebook-base-${replace(py_version, ".", "")}"
     }
 
-    name = "dask-${replace(py_version, ".", "")}"
+    name = "dask-notebook-${replace(py_version, ".", "")}"
     tags = tag(
         "dask-notebook",
         RELEASE,

--- a/bakefile.hcl
+++ b/bakefile.hcl
@@ -1,0 +1,142 @@
+variable "GH_REGISTRY" {
+    #default = "ghcr.io/dask"
+    default = "ghcr.io/ryanolee"
+}
+
+variable "DOCKER_HUB_REGISTRY" {
+    #default = "daskdev"
+}
+
+variable "RELEASE" {
+    default = "2024.9.1"
+}
+
+variable "STABLE" {
+    default = "true"
+}
+
+variable "DEFAULT_PY_VERSION" {
+    default = "3.10"
+}
+
+function "tags" {
+    params = [
+        image,
+        label
+    ]
+    result = [
+        "${GH_REGISTRY}/${image}:${label}",
+        #"${DOCKER_HUB_REGISTRY}/${image}:${label}"
+    ]
+}
+
+function "tag_stable" {
+    params = [
+        image,
+        release,
+        py_version
+    ]
+    result = concat(
+        tags(image, "${release}-py${py_version}"),
+        tags(image, "latest-py${py_version}"),
+        equal(py_version, DEFAULT_PY_VERSION) ? tags(image, "latest") : [],
+        equal(py_version, DEFAULT_PY_VERSION) ? tags(image, release) : []
+    )
+}
+
+function "tag_dev" {
+    params = [
+        image,
+        py_version
+    ]
+    result = concat(
+        tags(image, "dev-py${py_version}"),
+        equal(py_version, DEFAULT_PY_VERSION) ? tags(image, "dev") : []
+    )
+}
+
+function "tag" {
+    params = [
+        image,
+        release,
+        py_version
+    ]
+    result = equal(STABLE, "true") ? tag_stable(image, release, py_version) : tag_dev(image, py_version)
+}
+
+group "dask" {
+    targets = ["base", "notebook"]
+}
+
+target "base" {
+    context = "./base"
+    dockerfile = "Dockerfile"
+    platforms = ["linux/amd64", "linux/arm64"]
+    matrix = {
+        py_version = ["3.10", "3.11", "3.12"]
+    }
+    args = {
+        python = py_version
+        release = RELEASE
+    }
+    
+    name = "dask-${replace(py_version, ".", "")}"
+    tags = tag(
+        "dask",
+        RELEASE,
+        py_version
+    )
+}
+
+target "notebook-base" {
+    context = "https://github.com/jupyter/docker-stacks.git#main:images/docker-stacks-foundation"
+    dockerfile = "Dockerfile"
+    platforms = ["linux/amd64", "linux/arm64"]
+    matrix = {
+        py_version = ["3.12"]
+    }
+    args = {
+        PYTHON_VERSION = py_version
+    }
+    name = "notebook-base-${replace(py_version, ".", "")}"
+}
+
+# Pre 311 builds do not work due to https://github.com/jupyter/docker-stacks/issues/2146#issuecomment-2382315848
+# patch works for now. This can be collapsed into "notebook-base" once a fix has been released
+target "notebook-base-pre-311" {
+    context = "https://github.com/jupyter/docker-stacks.git#5365b9f79fa4ffbb20f10133cc6ac5bec5046302:images/docker-stacks-foundation"
+    dockerfile = "Dockerfile"
+    platforms = ["linux/amd64", "linux/arm64"]
+    matrix = {
+        py_version = ["3.10", "3.11"]
+    }
+    args = {
+        PYTHON_VERSION = py_version
+    }
+    name = "notebook-base-${replace(py_version, ".", "")}"
+}
+
+target "notebook" {
+    context = "./notebook"
+    dockerfile = "Dockerfile"
+    platforms = ["linux/amd64", "linux/arm64"]
+    matrix = {
+        py_version = ["3.12", "3.11", "3.10"]
+    }
+    args = {
+        python = py_version
+        release = RELEASE
+        base = "baseapp"
+    }
+
+    contexts = {
+        baseapp = "target:notebook-base-${replace(py_version, ".", "")}"
+    }
+
+    name = "dask-${replace(py_version, ".", "")}"
+    tags = tag(
+        "dask-notebook",
+        RELEASE,
+        py_version
+    )
+}

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,14 +10,15 @@ ENV PATH /opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${python}
 ENV DASK_VERSION=${release}
 
-RUN mamba install -y \
-    "mamba>=0.27.0" \
-    python=${PYTHON_VERSION} \
-    nomkl \
-    cmake \
-    dask=${DASK_VERSION} \
-    cachey \
-    streamz \
+RUN export G_SLICE=always-malloc \
+    && mamba install -y \
+        "mamba>=0.27.0" \
+        python=${PYTHON_VERSION} \
+        nomkl \
+        cmake \
+        dask=${DASK_VERSION} \
+        cachey \
+        streamz \
     && mamba clean -tipy \
     && find /opt/conda/ -type f,l -name '*.a' -delete \
     && find /opt/conda/ -type f,l -name '*.pyc' -delete \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -82,4 +82,4 @@ HEALTHCHECK  --interval=15s --timeout=3s --start-period=5s --retries=3 \
 USER $NB_USER
 
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]
-CMD ["jupyter", "lab", '--NotebookApp.base_url="${NB_PREFIX:-/}"', '${JUPYTERLAB_ARGS}']
+CMD jupyter lab --NotebookApp.base_url="${NB_PREFIX:-/}" ${JUPYTERLAB_ARGS}

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,6 +1,6 @@
 ARG base
 
-FROM $base/docker-stacks-foundation:lab
+FROM $base
 
 ARG release
 ARG python

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -82,4 +82,3 @@ HEALTHCHECK  --interval=15s --timeout=3s --start-period=5s --retries=3 \
 USER $NB_USER
 
 ENTRYPOINT ["tini", "--", "/usr/bin/prepare.sh"]
-CMD jupyter lab --NotebookApp.base_url="${NB_PREFIX:-/}" ${JUPYTERLAB_ARGS}

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -27,19 +27,20 @@ RUN MAGICARCH=$(dpkg --print-architecture) && \
 
 USER $NB_USER
 
-RUN mamba install -y \
-    python=${PYTHON_VERSION} \
-    nomkl \
-    cytoolz \
-    dask==${DASK_VERSION} \
-    lz4 \
-    numpy \
-    pandas \
-    ipywidgets \
-    cachey \
-    streamz \
-    jupyterlab \
-    "dask-labextension>=5" \
+RUN export G_SLICE=always-malloc \
+    && mamba install -y \
+        python=${PYTHON_VERSION} \
+        nomkl \
+        cytoolz \
+        dask==${DASK_VERSION} \
+        lz4 \
+        numpy \
+        pandas \
+        ipywidgets \
+        cachey \
+        streamz \
+        jupyterlab \
+        "dask-labextension>=5" \
     && mamba clean -tipy \
     && jupyter lab clean \
     && find /opt/conda/ -type f,l -name '*.a' -delete \

--- a/notebook/prepare.sh
+++ b/notebook/prepare.sh
@@ -35,4 +35,4 @@ fi
 
 
 # Execute the jupyterlab as specified.
-exec start.sh $@
+exec start.sh jupyter lab --NotebookApp.base_url="${NB_PREFIX:-/}" ${JUPYTERLAB_ARGS}


### PR DESCRIPTION
>[!NOTE]
>This is a request for comment, it is not a final implementation. I am happy to push it forwards to a completed state if it seems like it will be useful to the overall project structure / aims. Though given how substantial this change is to the overall build process can understand if the changes are too large for the stated aims of this PR.

>[!WARNING]
>It should be noted that bakefiles are still somewhat experimental https://docs.docker.com/build/bake/

First thanks all for the amazing project, really cool to try out this project! 

# What
This PR aims to address #290 #330 and #128 by migrating the build process from github actions into a docker bakefile for more centralized control over which docker files are built and to allow for multi-arch builds. 

# Why
In order to be able to build multiarch docker files so that ARM platforms can be tested with. Especially with ARM containers normally being cheaper to run on certain CaaS Platforms for similar amounts of compute. (Also I thought it would be funny to run dask on a raspberry Pi cluster🙊

# How
This PR implements a new [bakefile](https://docs.docker.com/build/bake/introduction/) which aims to simplify the overall build flow in CI offloading much of the responsibility to docker itself. 

It should be noted that:
 * Tagging as been replicated in the bakefile as it currently functions in CI
 * Base images are pulled directly from GIT to be built at the versions we require things to be built with

# How to test
See passing CI Jobs here: https://github.com/ryanolee/dask-docker/actions
And relevant docker images here:  https://github.com/ryanolee?tab=packages&repo_name=dask-docker

Try:
```yml
version: "3.1"

services:
  scheduler:
    image: ghcr.io/ryanolee/dask:2024.9.1-py3.12
    hostname: scheduler
    ports:
      - "8786:8786"
      - "8787:8787"
    command: ["dask-scheduler"]

  worker:
    image: ghcr.io/ryanolee/dask:2024.9.1-py3.12
    command: ["dask-worker", "tcp://scheduler:8786"]
    # For Docker swarm you can specify multiple workers, this is ignored by `docker-compose up`
    deploy:
      replicas: 4

  notebook:
    image: ghcr.io/ryanolee/dask-notebook:2024.9.1-py3.12
    ports:
      - "8888:8888"
    environment:
      - DASK_SCHEDULER_ADDRESS="tcp://scheduler:8786"
```

**OR**

Run `make build-docker` and import the images from your build context and reference them in a similar way.

Has been tested on 4 Node Raspberry Pi cluster using Docker swarm and works as expected for everything I have tried it with so for. 

x86 Builds have been tested on WSL2, Ubuntu 24.04 and have worked as expected also.