### PR TITLE
Patch issue with hanging docker builds on arm64 builds

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,8 @@ ENV PATH /opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${python}
 ENV DASK_VERSION=${release}
 
-RUN mamba install -y \
+RUN export G_SLICE=always-malloc \
+    && mamba install -y \
     "mamba>=0.27.0" \
     python=${PYTHON_VERSION} \
     nomkl \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -27,7 +27,8 @@ RUN MAGICARCH=$(dpkg --print-architecture) && \
 
 USER $NB_USER
 
-RUN mamba install -y \
+RUN export G_SLICE=always-malloc \
+    && mamba install -y \
     python=${PYTHON_VERSION} \
     nomkl \
     cytoolz \


### PR DESCRIPTION
# What
Resolves #338 using recommended as given by `mamba` documentation to stop hanging builds. (See issue for more details on issue)

# How
By exporting `G_SLICE=always-malloc` before calling Mamba

# Why
Builds currently have a random chance of hanging forever (see: https://github.com/dask/dask-docker/actions/runs/12659677038/job/35279267366)