### PR TITLE
Add Python 3.14 builds (#361)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         image:
           - tag: "daskdev/dask"
             context: "./base"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 | Image  | Description | Versions |
 | ------------- | ------------- | ------------- |
-| `ghcr.io/dask/dask`  | Base image to use for Dask scheduler and workers  |   [![][daskdev-dask-py310-release] ![][daskdev-dask-release] ![][daskdev-dask-latest] <br /> ![][daskdev-dask-py310-release] <br /> ![][daskdev-dask-py311-release] <br /> ![][daskdev-dask-py312-release] <br /> ![][daskdev-dask-py313-release]](https://github.com/dask/dask-docker/pkgs/container/dask)  |
-| `ghcr.io/dask/dask-notebook`  | Jupyter Notebook image to use as helper entrypoint  | [![][daskdev-dask-notebook-py310-release] ![][daskdev-dask-notebook-release] ![][daskdev-dask-notebook-latest] <br /> ![][daskdev-dask-notebook-py310-release] <br /> ![][daskdev-dask-notebook-py311-release] <br /> ![][daskdev-dask-notebook-py312-release] <br /> ![][daskdev-dask-notebook-py313-release]](https://github.com/dask/dask-docker/pkgs/container/dask-notebook) |
+| `ghcr.io/dask/dask`  | Base image to use for Dask scheduler and workers  |   [![][daskdev-dask-py310-release] ![][daskdev-dask-release] ![][daskdev-dask-latest] <br /> ![][daskdev-dask-py310-release] <br /> ![][daskdev-dask-py311-release] <br /> ![][daskdev-dask-py312-release] <br /> ![][daskdev-dask-py313-release] <br /> ![][daskdev-dask-py314-release]](https://github.com/dask/dask-docker/pkgs/container/dask)  |
+| `ghcr.io/dask/dask-notebook`  | Jupyter Notebook image to use as helper entrypoint  | [![][daskdev-dask-notebook-py310-release] ![][daskdev-dask-notebook-release] ![][daskdev-dask-notebook-latest] <br /> ![][daskdev-dask-notebook-py310-release] <br /> ![][daskdev-dask-notebook-py311-release] <br /> ![][daskdev-dask-notebook-py312-release] <br /> ![][daskdev-dask-notebook-py313-release] <br /> ![][daskdev-dask-notebook-py314-release]](https://github.com/dask/dask-docker/pkgs/container/dask-notebook) |
 
 [daskdev-dask-latest]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-latest-blue
 [daskdev-dask-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2026.3.0-blue
@@ -13,12 +13,14 @@
 [daskdev-dask-py311-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2026.3.0--py3.11-blue
 [daskdev-dask-py312-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2026.3.0--py3.12-blue
 [daskdev-dask-py313-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2026.3.0--py3.13-blue
+[daskdev-dask-py314-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask-2026.3.0--py3.14-blue
 [daskdev-dask-notebook-latest]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-latest-blue
 [daskdev-dask-notebook-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2026.3.0-blue
 [daskdev-dask-notebook-py310-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2026.3.0--py3.10-blue
 [daskdev-dask-notebook-py311-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2026.3.0--py3.11-blue
 [daskdev-dask-notebook-py312-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2026.3.0--py3.12-blue
 [daskdev-dask-notebook-py313-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2026.3.0--py3.13-blue
+[daskdev-dask-notebook-py314-release]: https://img.shields.io/badge/ghcr.io%2Fdask%2Fdask--notebook-2026.3.0--py3.14-blue
 
 
 ## Example


### PR DESCRIPTION
Adds Python 3.14 to the Docker build matrix, producing `py3.14`-tagged images for both `ghcr.io/dask/dask` and `ghcr.io/dask/dask-notebook`.

Changes:
- Add "3.14" to the Python matrix in `.github/workflows/build.yml`
- Add `py3.14` badge entries to `README.md`

Related to #357 which has failed tests since December 2025. 
3.13 was merged in a separate PR